### PR TITLE
href added in breadcrumbs example

### DIFF
--- a/inst/examples/Breadcrumbs.R
+++ b/inst/examples/Breadcrumbs.R
@@ -2,8 +2,8 @@ library(shiny.blueprint)
 library(shiny)
 
 items <- list(
-  list(icon = "folder-close", text = "Users"),
-  list(icon = "folder-close", text = "Janet"),
+  list(href = "/", icon = "folder-close", text = "Users"),
+  list(href = "/", icon = "folder-close", text = "Janet"),
   list(icon = "document", text = "image.jpg")
 )
 

--- a/man/Breadcrumbs.Rd
+++ b/man/Breadcrumbs.Rd
@@ -17,8 +17,8 @@ library(shiny.blueprint)
 library(shiny)
 
 items <- list(
-  list(icon = "folder-close", text = "Users"),
-  list(icon = "folder-close", text = "Janet"),
+  list(href = "/", icon = "folder-close", text = "Users"),
+  list(href = "/", icon = "folder-close", text = "Janet"),
   list(icon = "document", text = "image.jpg")
 )
 


### PR DESCRIPTION
Without `href` breadcrumbs are not clickable as in blueprint documentation example.