### PR TITLE
Cran resubmit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Description:
   and is optimized for building complex, data-dense web interfaces.
   This package provides most components from the underlying library,
   as well as special wrappers for some components
-  to make it easy to use them in R without writing JavaScript code.
+  to make it easy to use them in 'R' without writing 'JavaScript' code.
 License: LGPL-3
 Encoding: UTF-8
 LazyData: true

--- a/R/runExample.R
+++ b/R/runExample.R
@@ -5,6 +5,8 @@
 #'
 #' @param example The name of the example to run, or `NULL` to retrieve the list of examples.
 #' @param ... Additional arguments to pass to `shiny::runApp()`.
+#' @return This function normally does not return;
+#' interrupt R to stop the application (usually by pressing Ctrl+C or Esc).
 #'
 #' @export
 runExample <- function(example = NULL, ...) {

--- a/R/toaster.R
+++ b/R/toaster.R
@@ -22,6 +22,7 @@ Toaster <- R6::R6Class(
     #' @param toasterId Unique number - needed to use more than one toaster
     #' @param session Shiny session object
     #' @param ... Parameters passed to `Toaster` component
+    #' @return A new `Toaster` instance.
     initialize = function(
       toasterId = incrementToasterId(),
       session = shiny::getDefaultReactiveDomain(),
@@ -36,6 +37,7 @@ Toaster <- R6::R6Class(
     #' corresponding to the provided key
     #' @param ... Parameters passed to `Toaster` component
     #' @param key A key of toast to be shown/dismissed
+    #' @return Nothing. This method is called for side effects.
     show = function(..., key = NULL) {
       props <- list(...)
       private$session$sendCustomMessage(
@@ -48,6 +50,7 @@ Toaster <- R6::R6Class(
     },
 
     #' @description Dismiss all toasts instantly
+    #' @return Nothing. This method is called for side effects.
     clear = function() {
       private$session$sendCustomMessage(
         private$callName("clear"),
@@ -57,6 +60,7 @@ Toaster <- R6::R6Class(
 
     #' @description Dismiss the given toast instantly
     #' @param key A key of toast to be shown/dismissed
+    #' @return Nothing. This method is called for side effects.
     dismiss = function(key) {
       private$session$sendCustomMessage(
         private$callName("dismiss"),

--- a/man/Toaster.Rd
+++ b/man/Toaster.Rd
@@ -39,6 +39,9 @@ Documentation: \url{https://blueprintjs.com/docs/#core/components/toast}
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Returns}{
+A new \code{Toaster} instance.
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Toaster-show"></a>}}
@@ -59,6 +62,9 @@ corresponding to the provided key
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Returns}{
+Nothing. This method is called for side effects.
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Toaster-clear"></a>}}
@@ -69,6 +75,9 @@ Dismiss all toasts instantly
 \if{html}{\out{<div class="r">}}\preformatted{Toaster$clear()}\if{html}{\out{</div>}}
 }
 
+\subsection{Returns}{
+Nothing. This method is called for side effects.
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Toaster-dismiss"></a>}}
@@ -85,6 +94,9 @@ Dismiss the given toast instantly
 \item{\code{key}}{A key of toast to be shown/dismissed}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+Nothing. This method is called for side effects.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/runExample.Rd
+++ b/man/runExample.Rd
@@ -11,6 +11,10 @@ runExample(example = NULL, ...)
 
 \item{...}{Additional arguments to pass to \code{shiny::runApp()}.}
 }
+\value{
+This function normally does not return;
+interrupt R to stop the application (usually by pressing Ctrl+C or Esc).
+}
 \description{
 Launch a Shiny example app or list the available examples.
 Use \code{shiny.blueprint::runExample("showcase")} to run a showcase app with all the components.


### PR DESCRIPTION
### Changes
Address comments from CRAN review:

> We still see no \value in:
>       runExample.Rd: \value
>       Toaster.Rd: \value
> 
> Please always write package names, software names and API (application
> programming interface) names in single quotes in title and description.
> e.g: --> 'Palantir'; 'JavaScript'
> Please note that package names are case sensitive.
