### PR TITLE
chore: Disable clone() for Toaster R6 class

### DIFF
--- a/R/toaster.R
+++ b/R/toaster.R
@@ -18,6 +18,7 @@ incrementToasterId <- createIdIncrementationFunction()
 #' @export
 Toaster <- R6::R6Class(
   classname = "Toaster",
+  cloneable = FALSE,
   public = list(
     #' @param toasterId Unique number - needed to use more than one toaster
     #' @param session Shiny session object

--- a/man/Toaster.Rd
+++ b/man/Toaster.Rd
@@ -13,7 +13,6 @@ Documentation: \url{https://blueprintjs.com/docs/#core/components/toast}
 \item \href{#method-Toaster-show}{\code{Toaster$show()}}
 \item \href{#method-Toaster-clear}{\code{Toaster$clear()}}
 \item \href{#method-Toaster-dismiss}{\code{Toaster$dismiss()}}
-\item \href{#method-Toaster-clone}{\code{Toaster$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -97,23 +96,6 @@ Dismiss the given toast instantly
 }
 \subsection{Returns}{
 Nothing. This method is called for side effects.
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Toaster-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-Toaster-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Toaster$clone(deep = FALSE)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
 }
 }
 }


### PR DESCRIPTION
### Changes

Yet another attempt to please CRAN reviewers:

> in Toaster.Rd there is still  a \value-tag missing. Please make sure to
> change the correct corresponding .R-file and don't forget to
> roxigenize() the .Rd-file after changing the .R-file!
> 
>   Please fix and resubmit.

All the methods in the `Toaster` R6 class already have `@return` documentation; the only one without it was the auto-generated `clone()` method. As cloning doesn't make much sense for this class anyway, this PR adds `cloneable = FALSE` and regenerates the docs.
