### PR TITLE
fix: update branch name

### DIFF
--- a/inst/examples/showcase/app.R
+++ b/inst/examples/showcase/app.R
@@ -209,7 +209,7 @@ makeRouter <- function(items, routes) {
             target = "_blank",
             img(
               class = "logo",
-              src = "https://github.com/Appsilon/shiny.react/raw/master/man/figures/shiny-react.png"
+              src = "https://github.com/Appsilon/shiny.react/raw/main/man/figures/shiny-react.png"
             )
           )
         ),


### PR DESCRIPTION
Fixes missing image in the showcase app.

![image](https://github.com/Appsilon/shiny.blueprint/assets/38053499/a36fd2f7-b717-4d19-90cd-46508abe70e2)
